### PR TITLE
feat(shipped_delivered): Added action buttons

### DIFF
--- a/src/Components/Common/Cards.jsx
+++ b/src/Components/Common/Cards.jsx
@@ -44,6 +44,7 @@ console.log('CurDate::', curDateString);
 
 const Cards = ({ product }) => {
     const authToken = localStorage.getItem('AUTH_TOKEN');
+    console.log('token===>', authToken);
 
     const [quantity, setQuantity] = useState(1);
 

--- a/src/Components/Pages/AdminPanel.jsx
+++ b/src/Components/Pages/AdminPanel.jsx
@@ -1,6 +1,6 @@
 import React, { Fragment, Link } from 'react';
 import './AdminPanel.scss';
-import { Query } from 'react-apollo';
+import { Query, Mutation } from 'react-apollo';
 import gql from 'graphql-tag';
 import { ApolloConsumer } from 'react-apollo';
 
@@ -12,6 +12,27 @@ const GET_TRANSACTIONS = gql`
             user_id
             date
             product_id
+            currency
+            status
+        }
+    }
+`;
+
+const SHIP_DELIVERY_TRANSACTIONS = gql`
+    mutation ship_delivery_transaction(
+        $transaction_id: String!
+        $new_status: String!
+    ) {
+        ship_delivery_transaction(
+            transaction_id: $transaction_id
+
+            new_status: $new_status
+        ) {
+            id
+            quantity
+            user_id
+            product_id
+            date
             currency
             status
         }
@@ -132,6 +153,7 @@ const AdminPanel = () => {
                                             <th>Date</th>
                                             <th>currency</th>
                                             <th>Status</th>
+                                            <th>Actions</th>
                                         </tr>
                                         {dat &&
                                             dat.transactions &&
@@ -272,6 +294,80 @@ const AdminPanel = () => {
                                                         <td>
                                                             {transaction.status}
                                                         </td>
+
+                                                        <Mutation
+                                                            mutation={
+                                                                SHIP_DELIVERY_TRANSACTIONS
+                                                            }
+                                                        >
+                                                            {(
+                                                                ship_delivery_transaction,
+                                                                {
+                                                                    data,
+                                                                    loading,
+                                                                    error,
+                                                                },
+                                                            ) => {
+                                                                return (
+                                                                    <td>
+                                                                        <button
+                                                                            onClick={() => {
+                                                                                ship_delivery_transaction(
+                                                                                    {
+                                                                                        variables: {
+                                                                                            transaction_id:
+                                                                                                transaction.id,
+                                                                                            new_status:
+                                                                                                'Shipped',
+                                                                                        },
+                                                                                    },
+                                                                                ).then(
+                                                                                    (
+                                                                                        res,
+                                                                                    ) => {
+                                                                                        window.alert(
+                                                                                            transaction.id +
+                                                                                                ' is Shipped',
+                                                                                        );
+
+                                                                                        window.location.reload();
+                                                                                    },
+                                                                                );
+                                                                            }}
+                                                                        >
+                                                                            Shipped
+                                                                        </button>
+                                                                        <button
+                                                                            onClick={() => {
+                                                                                ship_delivery_transaction(
+                                                                                    {
+                                                                                        variables: {
+                                                                                            transaction_id:
+                                                                                                transaction.id,
+                                                                                            new_status:
+                                                                                                'Delivered',
+                                                                                        },
+                                                                                    },
+                                                                                ).then(
+                                                                                    (
+                                                                                        res,
+                                                                                    ) => {
+                                                                                        window.alert(
+                                                                                            transaction.id +
+                                                                                                ' is Delivered',
+                                                                                        );
+
+                                                                                        window.location.reload();
+                                                                                    },
+                                                                                );
+                                                                            }}
+                                                                        >
+                                                                            Delivered
+                                                                        </button>
+                                                                    </td>
+                                                                );
+                                                            }}
+                                                        </Mutation>
                                                     </tr>
                                                 ),
                                             )}

--- a/src/Components/Pages/Cart.jsx
+++ b/src/Components/Pages/Cart.jsx
@@ -77,7 +77,7 @@ const Cart = () => {
                                         variables: {
                                             user_id: uid,
                                             cur_status: 'inCart',
-                                            new_status: 'Shipped',
+                                            new_status: 'placed order',
                                         },
                                     }).then((res) => {
                                         if (

--- a/src/Components/Pages/Home.jsx
+++ b/src/Components/Pages/Home.jsx
@@ -41,7 +41,8 @@ const Home = () => {
                                     </div>
                                 ))
                             ) : (
-                                localStorage.removeItem('AUTH_TOKEN')
+                                //localStorage.removeItem('AUTH_TOKEN')
+                                console.log('removing token')
                             )}
                         </div>
                     </div>


### PR DESCRIPTION
Added two action buttons 'shipped' and 'delivered' in the admin panel.

These buttons can be used to change the status of the transactions to shipped and delivered.

![shipped_delivered](https://user-images.githubusercontent.com/7887404/58473447-3e193f00-8166-11e9-94a3-920ee5823202.PNG)





